### PR TITLE
Fix 'No such variable: "b:current_syntax"'

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -61,7 +61,9 @@ if !exists("main_syntax")
 endif
 
 runtime syntax/html.vim
-unlet b:current_syntax
+if exists("b:current_syntax")
+    unlet b:current_syntax
+endif
 
 " Set sync method if none declared
 if !exists("php_sync_method")


### PR DESCRIPTION
Error detected while processing $VIMFILES/phpvim/syntax/php.vim:
E108: No such variable: "b:current_syntax"
